### PR TITLE
Added .cginc file extension to shadercode-cg.

### DIFF
--- a/grammars/shadercode-cg.cson
+++ b/grammars/shadercode-cg.cson
@@ -3,6 +3,7 @@
 'fileTypes': [
   'fx'
   'cg'
+  'cginc'
   'shader'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'


### PR DESCRIPTION
Nice-to-have for those of us who operate mostly outside of snippets.